### PR TITLE
改进 ego/do-publish 的功能（减少 change-branch 的错误问题）

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,6 +25,33 @@ EGO provides features below:
 
 * Workflow
 
+The files-flow of EGO is showed on Graph below:
+
+: 
+:           +-----------<-------------+----<---------------+-----------<--------------<------------------+
+:           |                         |                    |                                             |
+:           | re-test or        if you want to re-test...  |-tested publish if you think test is OK      |
+:           | untested publish                            \|/                                            |
+:           |                                                all html files test -|                      |
+:           |                        > Web Test Dir ------------------------->----+-->-Web-Test-Dir-->---+
+:           |                      / |                                          \       /
+:          \|/   all org files --/-  |                                           \     /- partial html files test
+:                              /-    |                                            v   ^
+:                            /-      |                                             \ /
+: EGO Repo  -+-------------->     org-to-html                                       X
+:            |               \-      |                                             / \
+:            |                 \-    |                                            ^   v
+:            | changed org files-\-  |                                           /     \- all html files publish
+:            |                     \ |                                          /       \       
+:       git gets changed files      >"~/.ego-tmp/"Dir ----------------------->-----+->-Publish-Repository-->-up-load-flies
+:                                                       partial html files publish-|
+:                                                                                                                                         
+
+MENTION: The global variable =ego/publish-to-repository=
+
+1) partial org-files publish without org-to-html: it equals 1
+2) all org-files publish without org-to-html: it equals 2
+
 1. Specify a git repo where the org source
    files will be on the "source" branch and the generated html files
    will be on the "master" branch (the branch names can be
@@ -81,6 +108,15 @@ C-h v ego/project-config-alist
 C-h v ego/config-fallback
 #+END_EXAMPLE
 
+** create new repository
+Using the following command to create a new repository:
+
+#+BEGIN_EXAMPLE
+M-x ego/new-repository
+#+END_EXAMPLE
+
+The repository is preliminary, you have to configure the =ego/project-config-alist= to make it work!
+
 ** create new post
 Using the following command to create a new post:
 
@@ -114,6 +150,70 @@ or:
 
 #+BEGIN_SRC emacs-lisp
 (call-interactively 'ego/do-publication)
+#+END_SRC
+
+** Async Publication
+You can use =async.el= package to wrap the command =ego/do-publication= in order to publish the static site without a wait.
+
+You can find some example about how to use =async.el= package here : [[https://github.com/jwiegley/emacs-async][Async]].
+
+And here is an example: (There are some important point so that you had better see it.)
+
+#+BEGIN_SRC emacs-lisp
+  (require 'async)
+  (defun ego/async-do-publish (&optional project-name
+                                         force-all
+                                         base-git-commit
+                                         test-and-not-publish
+                                         checkin-all
+                                         publish-all)
+    (interactive
+     (let* ((j (or ego/default-project-name
+                   (completing-read "Which project do you want to publish? "
+                                    (delete-dups
+                                     (mapcar 'car ego/project-config-alist))
+                                    nil t nil nil ego/last-project-name)))
+            (f (y-or-n-p (format "Publish all org files of \"%s\" project? " j)))
+            (b (unless f (read-string "Base git commit: " "HEAD~1")))
+            (p (progn (setq ego/current-project-name j)
+                      (setq ego/last-project-name j)
+                      (y-or-n-p "Action:  [Yes] Test, [No] Tested Publish. ")))
+            (c (y-or-n-p "checkin all org files? (input 'n' if you have done it)"))
+            (a (unless p (y-or-n-p "publish all branch? "))))
+       (list j f b p c a)))
+    (async-start
+     `(lambda ()
+        (setq package-user-dir ,(expand-file-name "~/.emacs.d/elpa/"))
+        (package-initialize t)
+        (add-to-list 'load-path ,(expand-file-name "~/github/org-mode/lisp"))
+        (add-to-list 'load-path ,(expand-file-name "~/github/org-mode/contrib/lisp" t))
+        (add-to-list 'load-path ,ego/load-directory)
+        (require 'ego)
+        (setq ego/project-config-alist ',ego/project-config-alist)
+        (require 'simple-httpd)
+        (advice-add 'ego/web-server-browse
+                    :override
+                    (lambda ()
+                      (interactive)
+                      (setq httpd-port (ego/get-config-option :web-server-port))
+                      (httpd-serve-directory (ego/get-config-option :web-server-docroot))
+                      (browse-url (format "http://%s:%d" system-name httpd-port))))
+        (unless test-and-not-publish
+          (if base-git-commit
+              (setq ego/publish-to-repository 1)
+            (setq ego/publish-to-repository 2)))
+        (ego/do-publication project-name
+                            force-all
+                            base-git-commit
+                            test-and-not-publish
+                            checkin-all
+                            publish-all)
+        (with-current-buffer (get-buffer-create ,ego/temp-buffer-name)
+          (buffer-string))
+        )
+     `(lambda (result)
+        (message "ego/async-do-publish done, *EGO output* should be : %s" result)
+        )))
 #+END_SRC
 
 * Dependencies

--- a/ego-config.el
+++ b/ego-config.el
@@ -302,7 +302,7 @@ You can see fallback value of above option in `ego/config-fallback'"
   :group 'ego
   :type 'function)
 
-(defconst ego/temp-buffer-name "*Org Page Output*"
+(defconst ego/temp-buffer-name "*EGO Output*"
   "Name of the temporary buffer used by ego.")
 
 (defconst ego/load-directory

--- a/ego-config.el
+++ b/ego-config.el
@@ -339,12 +339,14 @@ You can see fallback value of above option in `ego/config-fallback'"
      :category-index nil))
   "Configurations for different categories, can and should be customized.")
 
-(defvar ego/category-show-list nil "the list of category names(string) which will be showed in the navigation-bar")
+(defvar ego/category-show-list nil
+  "the list of category names(string) which will be showed in the navigation-bar")
 
 (defvar ego/current-project-name nil)
 (defvar ego/last-project-name nil)
 
-(defvar ego/publish-to-repository nil)
+(defvar ego/publish-to-repository nil
+  "partial org-files publish without org-html: 1; all org-files publish without org-html: 2")
 
 (defvar ego/item-cache nil
   "The cache for general purpose.")

--- a/ego-git.el
+++ b/ego-git.el
@@ -29,7 +29,7 @@
 
 (require 'ox)
 (require 'ht)
-(require 'ego-util) 
+(require 'ego-util)
 (require 'ego-config)
 
 
@@ -47,10 +47,10 @@ command to be executed."
   (if need-git
       (ego/verify-git-repository dir))
   (with-current-buffer (get-buffer-create ego/temp-buffer-name)
-    (erase-buffer)
+    ;;(erase-buffer)
     (setq default-directory (file-name-as-directory dir))
     (shell-command command t nil)
-    (buffer-string)))
+    (buffer-substring (region-beginning) (region-end))))
 
 (defun ego/git-all-files (repo-dir &optional branch)
   "This function will return a list contains all org files in git repository
@@ -95,7 +95,7 @@ TODO: verify if the branch exists."
                  repo-dir
                  (concat "env LC_ALL=C git checkout -b " branch-name)
                  t)))
-    (unless (string-match "Switched to a new branch" output)
+    (unless (or (string-match "Switched to a new branch" output) (string-match "already exists"))
       (error "Fatal: Failed to create a new branch with name '%s'."
              branch-name))))
 
@@ -105,8 +105,14 @@ by REPO-DIR. Do nothing if it is current branch."
   (let ((repo-dir (file-name-as-directory repo-dir))
         (output (ego/shell-command
                  repo-dir
-                 (concat "env LC_ALL=C git checkout " branch-name)
+                 "env LC_ALL=C git status"
                  t)))
+    (when (not (string-match "nothing to commit" output))
+      (error "The branch have something uncommitted, recheck it!"))
+    (setq output (ego/shell-command
+                 repo-dir
+                 (concat "env LC_ALL=C git checkout " branch-name)
+                 t))
     (when (string-match "\\`error" output)
       (error "Failed to change branch to '%s' of repository '%s'."
              branch-name repo-dir))))
@@ -129,7 +135,7 @@ REPO-DIR, MESSAGE is the commit message."
           (ego/shell-command repo-dir
                              (format "env LC_ALL=C git commit -m \"%s\"" message)
                              t))
-    (when (not (string-match "\\[.* .*\\]" output))
+    (when (not (or (string-match "\\[.* .*\\]" output) (string-match "nothing to commit" output)))
       (error "Failed to commit changes on current branch of repository '%s'."
              repo-dir))))
 
@@ -187,15 +193,15 @@ local git repository, REMOTE-REPO is the remote repository, BRANCH is the name
 of branch will be pushed (the branch name will be the same both in local and
 remote repository), and if there is no branch named BRANCH in remote repository,
 it will be created."
-  (let ((repo-dir (file-name-as-directory repo-dir))
-        (output (ego/shell-command
-                 repo-dir
-                 (concat "env LC_ALL=C git push " remote-repo " " branch ":" branch)
-                 t)))
-    (when (or (string-match "fatal" output)
-              (string-match "error" output))
-      (error "Failed to push branch '%s' to remote repository '%s'."
-             branch remote-repo))))
+  (let* ((default-directory (file-name-as-directory repo-dir))
+         (cmd (append '("git")
+                      `("push" ,remote-repo ,(concat branch ":" branch))))
+         (proc (apply #'start-process "EGO-Async" ego/temp-buffer-name cmd)))
+    (set-process-filter proc `(lambda (proc output)
+                               (when (or (string-match "fatal" output)
+                                         (string-match "error" output))
+                                 (error "Failed to push branch '%s' to remote repository '%s'."
+                                        ,branch ,remote-repo))))))
 
 
 (provide 'ego-git)

--- a/ego-template.el
+++ b/ego-template.el
@@ -134,7 +134,7 @@ render from a default hash table."
                (mapcar
                 #'(lambda (cat)
                     (if (equal cat (caar (seq-filter #'(lambda (element) (equal :tags (cadr element)))
-                                                    (ego/get-config-option :summary))))
+                                                     (ego/get-config-option :summary))))
                         (setq cat-real "tags")
                       (setq cat-real cat))
                     (ht ("summary-item-uri"

--- a/ego.el
+++ b/ego.el
@@ -131,19 +131,23 @@ then the \"html-branch\"  will be pushed to remote repo."
     (setq addition-files
           (when (functionp addition-files-function)
             (funcall addition-files-function repo-dir)))
+    (when (y-or-n-p "checkin all org files? (input 'n' if you have done it)")
+      (ego/git-commit-changes repo-dir "checkin all org files by EGO"))
     (setq changed-files (if force-all
                             `(:update ,repo-files :delete nil)
+                          (message "Getting all changed files, just waiting...")
                           (ego/git-files-changed repo-dir (or base-git-commit "HEAD~1"))))
+    (message "pre-publish all files needed to be publish, waiting...")
     (ego/publish-changes repo-files addition-files changed-files store-dir)
+    (message "pre-publish accomplished ~ begin real publish")
     (when to-repo
-      (when (y-or-n-p "commit all org files? (input 'n' if you have committed all org files)")
-        (ego/git-commit-changes repo-dir "checkin all org files by EGO"))
       (ego/git-change-branch repo-dir html-branch)
       (copy-directory store-dir repo-dir t t t)
       (delete-directory store-dir t))
     (when (and to-repo auto-commit)
       (ego/git-commit-changes repo-dir (concat "Update published html files, "
-                                               "committed by ego."))
+                                               "committed by EGO."))
+      (message "Local publish finished, see *EGO output* buffer to get more information (Such as \"remote publish condition\")")
       (when auto-push
         (setq remote-repos (ego/git-remote-name repo-dir))
         (if (not remote-repos)
@@ -178,6 +182,7 @@ perfectly manipulated by ego."
   (ego/git-init-repo repo-dir)
   (ego/generate-readme repo-dir)
   (ego/git-commit-changes repo-dir "initial commit")
+  (ego/git-new-branch repo-dir (ego/get-config-option :repository-html-branch))
   (ego/git-new-branch repo-dir (ego/get-config-option :repository-org-branch))
   (ego/generate-index repo-dir)
   (ego/git-commit-changes repo-dir "add source index.org")

--- a/ego.el
+++ b/ego.el
@@ -67,8 +67,10 @@
 
 (defun ego/do-publication (&optional project-name
                                      force-all
-                                     base-git-commit pub-base-dir
-                                     auto-commit auto-push)
+                                     base-git-commit
+                                     test-and-not-publish
+                                     checkin-all
+                                     publish-all)
   "The main entrance of ego. The entire procedure is:
 1) verify configuration
 2) read changed files on \"org branch\" of \"repository directory\",
@@ -77,16 +79,12 @@
       will be published.
    2. if FORCE-ALL is nil, the changed files will be obtained based on
       BASE-GIT-COMMIT
-   3. if BASE-GIT-COMMIT is nil or omitted, the changed files will be obtained
-      based on previous commit
-3) publish org files to html, if PUB-BASE-DIR is specified, use that directory
-   to store the generated html files, otherwise html files will be stored on \"html-branch\"
-   of \"repository directory\".
-4) if PUB-BASE-DIR is nil, and AUTO-COMMIT is non-nil, then the changes stored
-   on \"html-branch\" will be automatically committed, but be careful, this feature is
-   NOT recommended, and a manual commit is much better
-5) if PUB-BASE-DIR is nil, AUTO-COMMIT is non-nil, and AUTO-PUSH is non-nil,
-then the \"html-branch\"  will be pushed to remote repo."
+   3. if BASE-GIT-COMMIT is nil or omitted, the changed files will be obtained based on previous commit
+3) publish org files to html,
+   if TEST-AND-NOT-PUBLISH is t, test the generated html files by the web-server,
+   otherwise html files will be published on \"html-branch\" of \"repository directory\" and pushed to the remote repository.
+4) CHECKIN-ALL will checkin all the org-files, input 'n' if you have done it or don't want to checkin all.
+5) PUBLISH-ALL will publish all branch in the repository, input 'n' if you don't want to publish all. "
   (interactive
    (let* ((j (or ego/default-project-name
                  (completing-read "Which project do you want to publish? "
@@ -97,14 +95,10 @@ then the \"html-branch\"  will be pushed to remote repo."
           (b (unless f (read-string "Base git commit: " "HEAD~1")))
           (p (progn (setq ego/current-project-name j)
                     (setq ego/last-project-name j)
-                    (when (y-or-n-p
-                           "Publish to:  [Yes] Web server docroot, [No] Original repo. ")
-                      (expand-file-name (ego/get-config-option :web-server-docroot)))))
-          (a (when (and (not p))
-               (y-or-n-p "Auto commit to repo? ")))
-          (u (when (and a (not p))
-               (y-or-n-p "Auto push to remote repo? "))))
-     (list j f b p a u)))
+                    (y-or-n-p "Publish to:  [Yes] Web server docroot, [No] Original repo. ")))
+          (c (y-or-n-p "checkin all org files? (input 'n' if you have done it)"))
+          (a (unless p (y-or-n-p "publish all branch? "))))
+     (list j f b p c a)))
 
   (let ((preparation-function
          (ego/get-config-option :preparation-function)))
@@ -119,63 +113,81 @@ then the \"html-branch\"  will be pushed to remote repo."
          (repo-files-function (ego/get-config-option :repo-files-function))
          (addition-files-function (ego/get-config-option :addition-files-function))
          (orig-branch (ego/git-branch-name repo-dir))
-         (to-repo (not (stringp pub-base-dir)))
-         (store-dir (if to-repo "~/.ego-tmp/" pub-base-dir)) ; TODO customization
-         (ego/publish-to-repository to-repo)
+         (to-repo (not test-and-not-publish))
+         (test-dir (expand-file-name (ego/get-config-option :web-server-docroot)))
+         (store-dir (if (not base-git-commit)
+                        test-dir
+                      "~/.ego-tmp/")) ; TODO customization
+         (base-git-commit-test (if base-git-commit 1 2))
          repo-files addition-files changed-files remote-repos)
     (ego/git-change-branch repo-dir org-branch)
-    (ego/prepare-theme-resources store-dir)
     (setq repo-files
           (when (functionp repo-files-function)
             (funcall repo-files-function repo-dir)))
     (setq addition-files
           (when (functionp addition-files-function)
             (funcall addition-files-function repo-dir)))
-    (when (y-or-n-p "checkin all org files? (input 'n' if you have done it)")
+    (when checkin-all
       (ego/git-commit-changes repo-dir "checkin all org files by EGO"))
-    (setq changed-files (if force-all
-                            `(:update ,repo-files :delete nil)
-                          (message "Getting all changed files, just waiting...")
-                          (ego/git-files-changed repo-dir (or base-git-commit "HEAD~1"))))
-    (message "pre-publish all files needed to be publish, waiting...")
-    (ego/publish-changes repo-files addition-files changed-files store-dir)
-    (message "pre-publish accomplished ~ begin real publish")
-    (when to-repo
-      (ego/git-change-branch repo-dir html-branch)
-      (copy-directory store-dir repo-dir t t t)
-      (delete-directory store-dir t))
-    (when (and to-repo auto-commit)
-      (ego/git-commit-changes repo-dir (concat "Update published html files, "
-                                               "committed by EGO."))
-      (message "Local publish finished, see *EGO output* buffer to get more information (Such as \"remote publish condition\")")
-      (when auto-push
-        (setq remote-repos (ego/git-remote-name repo-dir))
-        (if (not remote-repos)
-            (message "No valid remote repository found.")
-          (let (repo)
-            (if (> (length remote-repos) 1)
-                (setq repo (read-string
-                            (format "Which repo to push %s: "
-                                    (prin1-to-string remote-repos))
-                            (car remote-repos)))
-              (setq repo (car remote-repos)))
-            (if (not (member repo remote-repos))
-                (message "Invalid remote repository '%s'." repo)
-              (ego/git-push-remote repo-dir
-                                   repo
-                                   html-branch)))))
-      (ego/git-change-branch repo-dir orig-branch))
-    (if to-repo
-        (message "Publication finished: on branch '%s' of repository '%s'."
-                 html-branch repo-dir)
-      (message "Publication finished, output directory: %s." pub-base-dir)
-      (when (called-interactively-p 'any)
-        (ego/web-server-browse)))
+    (when (or (not (equal base-git-commit-test ego/publish-to-repository))
+              test-and-not-publish)
+      (setq changed-files (if force-all
+                              `(:update ,repo-files :delete nil)
+                            (message "Getting all changed files, just waiting...")
+                            (ego/git-files-changed repo-dir (or base-git-commit "HEAD~1"))))
+      (setq ego/publish-to-repository to-repo)
+      (when (file-directory-p store-dir)
+        (delete-directory store-dir t t))
+      (make-directory store-dir)
+      (ego/prepare-theme-resources store-dir)
+      (message "Pre-publish all files needed to be publish, waiting...")
+      (ego/publish-changes repo-files addition-files changed-files store-dir)
+      (message "Pre-publish finished, output directory: %s." store-dir)
+      (setq ego/publish-to-repository nil))
+    (ego/git-change-branch repo-dir html-branch)
+    (cond (test-and-not-publish
+           (unless (file-directory-p test-dir)
+             (make-directory test-dir))
+           (when (called-interactively-p 'any)
+             (if (not base-git-commit)
+                 (setq ego/publish-to-repository 2)
+               (copy-directory repo-dir test-dir t t t)
+               (copy-directory store-dir test-dir t t t)
+               (setq ego/publish-to-repository 1))
+             (ego/web-server-browse)))
+          (to-repo
+           (message "pre-publish accomplished ~ begin real publish")
+           ;;left the part below for async
+           (copy-directory store-dir repo-dir t t t)
+           (ego/git-commit-changes repo-dir (concat "Update published html files, "
+                                                    "committed by EGO."))
+           (ego/git-change-branch repo-dir orig-branch)
+           ;;left the part above for async
+
+           (message "Local publish finished, see *EGO output* buffer to get more information (Such as \"remote publish condition\")")
+           (setq remote-repos (ego/git-remote-name repo-dir))
+           (if (not remote-repos)
+               (message "No valid remote repository found.")
+             (let (repo)
+               (if (> (length remote-repos) 1)
+                   (setq repo (read-string
+                               (format "Which repo to push %s: "
+                                       (prin1-to-string remote-repos))
+                               (car remote-repos)))
+                 (setq repo (car remote-repos)))
+               (if (not (member repo remote-repos))
+                   (message "Invalid remote repository '%s'." repo)
+                 (ego/git-push-remote repo-dir
+                                      repo
+                                      html-branch publish-all))))
+           (message "Publication finished: on branch '%s' of repository '%s'." html-branch repo-dir)))
+    (ego/git-change-branch repo-dir orig-branch)
     (setq ego/current-project-name nil)))
 
 (defun ego/new-repository (repo-dir)
   "Generate a new git repository in directory REPO-DIR, which can be
-perfectly manipulated by ego."
+perfectly manipulated by EGO. In order to construct a real repository,
+you must customize the variable `ego/project-config-alist' according to the readme file of EGO project."
   (interactive
    (list (read-directory-name
           "Specify a directory to become the repository: " nil nil nil)))

--- a/themes/default/resources/css/main.css
+++ b/themes/default/resources/css/main.css
@@ -382,6 +382,7 @@ table th.right, table td.right {
 }
 
 .center { margin-left: auto; margin-right: auto; text-align: center; }
+.org-center { margin-left: auto; margin-right: auto; text-align: center; }
 
 /* table of content */
 #table-of-contents {

--- a/themes/default/templates/footer.mustache
+++ b/themes/default/templates/footer.mustache
@@ -70,7 +70,7 @@
     <p>
       Copyright &copy; 2014 - <span id="footerYear"></span> <a href="mailto:{{email}}">{{author}}</a>
       &nbsp;&nbsp;-&nbsp;&nbsp;
-      Powered by <a href="https://github.com/emacs-china/ego" target="_blank">ego</a><br/>
+      Powered by <a href="https://github.com/emacs-china/ego" target="_blank">EGO</a><br/>
       <a href="http://creativecommons.org/licenses/by-sa/3.0/" rel="license"><img src="http://i.creativecommons.org/l/by-sa/3.0/88x31.png" style="border-width:0" alt="Creative Commons License" class="center"></a>
       <script type="text/javascript">document.getElementById("footerYear").innerHTML = (new Date()).getFullYear();</script>
     </p>


### PR DESCRIPTION
根据 README 上的介绍，可以将 ego/do-publish 的异步功能由 async 包实现（这样可以使得 org-to-html 这部分也异步运行），需根据自己的 emacs 环境手动设置。

后期打算使用 deferred 库，但是可能要重写 ego-git.el 全部代码。

remote push 已经用 start-process 异步实现。
