### PR TITLE
fix missing require for `seq`

### DIFF
--- a/ego.el
+++ b/ego.el
@@ -60,6 +60,7 @@
 (require 'ego-export)
 (require 'ego-web-server)
 (require 'cl-lib)
+(require 'seq)
 
 (defconst ego-version "0.1")
 


### PR DESCRIPTION
```
Read header.mustache from file
Render navigation bar from template
Read nav.mustache from file
caar: Symbol's function definition is void: seq-filter
```
```
GNU Emacs 24.5.1 (x86_64-apple-darwin13.4.0, NS apple-appkit-1265.21) of 2015-04-11 on builder10-9.porkrind.org
```